### PR TITLE
Add policy.json

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -29,6 +29,7 @@ COPY --from=osdk-builder /opt/app-root/src/operator-sdk /bin
 COPY --from=opm-builder /opt/app-root/src/opm /bin
 COPY --from=kustomize-builder /opt/app-root/src/kustomize/kustomize /bin
 COPY --from=controller-gen-builder /opt/app-root/src/controller-gen /bin
+COPY files/policy.json /etc/containers/policy.json
 
 ARG INSTALLED_RPMS="gettext make"
 RUN microdnf install -y gettext

--- a/files/policy.json
+++ b/files/policy.json
@@ -1,0 +1,32 @@
+{
+    "default": [
+        {
+            "type": "insecureAcceptAnything"
+        }
+    ],
+    "transports": {
+        "docker": {
+	    "registry.access.redhat.com": [
+		{
+		    "type": "signedBy",
+		    "keyType": "GPGKeys",
+		    "keyPaths": ["/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release", "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta"]
+		}
+	    ],
+	    "registry.redhat.io": [
+		{
+		    "type": "signedBy",
+		    "keyType": "GPGKeys",
+		    "keyPaths": ["/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release", "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta"]
+		}
+	    ]
+	},
+        "docker-daemon": {
+	    "": [
+		{
+		    "type": "insecureAcceptAnything"
+		}
+	    ]
+	}
+    }
+}


### PR DESCRIPTION
This file needs to be present when running `opm` directly inside container.
`opm` execution is done inside `run-opm-command` task for `fbc-builder` pipeline in `build-definitions`.

[KONFLUX-5311]

## Summary by Sourcery

Include a policy.json file in the container image to configure container policies for opm execution in the fbc-builder pipeline

Enhancements:
- Add files/policy.json to define container policy configurations
- Copy policy.json into /etc/containers/policy.json in the Containerfile