### PR TITLE
Fix make RPM installation

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -32,7 +32,7 @@ COPY --from=controller-gen-builder /opt/app-root/src/controller-gen /bin
 COPY files/policy.json /etc/containers/policy.json
 
 ARG INSTALLED_RPMS="gettext make"
-RUN microdnf install -y ${INSTALLED_RPMS}
+RUN microdnf install -y ${INSTALLED_RPMS} && microdnf clean all
 
 ENTRYPOINT ["/bin/operator-sdk"]
 


### PR DESCRIPTION
Commit [1] added `make` to a list of installed RPMs, but that list is never passed to `microdnf` so it's never actually installed.

This fixes that, which will allow building operators that use Makefiles.

[1] https://github.com/konflux-ci/operator-sdk-builder/commit/371bef21f617b02cc8bfc9a5ef21d6c9c92b50c2

## Summary by Sourcery

Bug Fixes:
- Use INSTALLED_RPMS variable in microdnf install command so that make (and other listed RPMs) are installed