### PR TITLE
Add go so controller-gen can run.

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -22,7 +22,7 @@ COPY --chown=default ./controller-tools/. /opt/app-root/src/
 WORKDIR /opt/app-root/src
 RUN ls -l && CGO_ENABLED=0 GOOS=linux go build -a -o controller-gen ./cmd/controller-gen
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:0d7cfb0704f6d389942150a01a20cb182dc8ca872004ebf19010e2b622818926
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24.4-1754467841
 
 COPY LICENSE /licenses
 COPY --from=osdk-builder /opt/app-root/src/operator-sdk /bin
@@ -31,8 +31,12 @@ COPY --from=kustomize-builder /opt/app-root/src/kustomize/kustomize /bin
 COPY --from=controller-gen-builder /opt/app-root/src/controller-gen /bin
 COPY files/policy.json /etc/containers/policy.json
 
+ENV GOROOT=/usr/lib/golang
+ENV PATH=${PATH}:${GOROOT}/bin
+
+USER root
 ARG INSTALLED_RPMS="gettext make"
-RUN microdnf install -y ${INSTALLED_RPMS} && microdnf clean all
+RUN dnf install -y ${INSTALLED_RPMS} && dnf clean all
 
 ENTRYPOINT ["/bin/operator-sdk"]
 


### PR DESCRIPTION
Put go on the resulting image as controller-gen needs it in order to run.

## Summary by Sourcery

Build:
- Copy Go runtime from the builder stage into the final image and update PATH