### PR TITLE
Add registry.access.redhat.com.yaml and registry.redhat.io.yaml

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -30,6 +30,8 @@ COPY --from=opm-builder /opt/app-root/src/opm /bin
 COPY --from=kustomize-builder /opt/app-root/src/kustomize/kustomize /bin
 COPY --from=controller-gen-builder /opt/app-root/src/controller-gen /bin
 COPY files/policy.json /etc/containers/policy.json
+COPY files/registry.access.redhat.com.yaml /etc/containers/registries.d/registry.access.redhat.com.yaml
+COPY files/registry.redhat.io.yaml /etc/containers/registries.d/registry.redhat.io.yaml
 
 ENV GOROOT=/usr/lib/golang
 ENV PATH=${PATH}:${GOROOT}/bin

--- a/files/registry.access.redhat.com.yaml
+++ b/files/registry.access.redhat.com.yaml
@@ -1,0 +1,5 @@
+---
+# enabling signature verification for registry.access.redhat.com
+docker:
+     registry.access.redhat.com:
+         sigstore: https://access.redhat.com/webassets/docker/content/sigstore

--- a/files/registry.redhat.io.yaml
+++ b/files/registry.redhat.io.yaml
@@ -1,0 +1,5 @@
+---
+# enabling signature verification for registry.redhat.io
+docker:
+     registry.redhat.io:
+         sigstore: https://registry.redhat.io/containers/sigstore


### PR DESCRIPTION
These files need to be present when running opm directly inside container. Otherwise opm command fails with message: Source image rejected: A signature was required, but no signature exists

opm execution is done inside run-opm-command task for fbc-builder pipeline in build-definitions.

[KFLUXSPRT-5013]

## Summary by Sourcery

Enable signature verification for registry.access.redhat.com and registry.redhat.io when running opm inside the container by adding the necessary registry configuration files and copying them into the container image.

Enhancements:
- Add registry.access.redhat.com.yaml and registry.redhat.io.yaml with sigstore URLs
- Update Containerfile to copy the new registry config files into /etc/containers/registries.d