### PR TITLE
feat: add yq to the operator-sdk-builder image

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,3 +14,6 @@
 	path = controller-tools
 	url = https://github.com/kubernetes-sigs/controller-tools.git
 	branch = master
+[submodule "yq"]
+	path = yq
+	url = https://github.com/mikefarah/yq.git

--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -62,6 +62,8 @@ spec:
     - {path: operator-sdk, type: gomod}
         # controller-tools submodule
     - {path: controller-tools, type: gomod}
+        # yq submodule
+    - {path: yq, type: gomod}
         # RPMs
     - {path: ., type: rpm}
     description: Build dependencies to be prefetched by Cachi2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ The final image includes:
 - **controller-gen** — Kubernetes API code generator
 - **opm** — Operator Registry package manager
 - **kustomize** — Kubernetes configuration management
+- **yq** — YAML/JSON/XML processor and parser
 - **envsubst** — GNU gettext environment variable substitution
 
 ## Repository Structure
@@ -21,6 +22,7 @@ The final image includes:
 ├── kustomize/                 # Submodule: kubernetes-sigs/kustomize
 ├── operator-registry/         # Submodule: operator-framework/operator-registry
 ├── controller-tools/          # Submodule: kubernetes-sigs/controller-tools
+├── yq/                        # Submodule: mikefarah/yq
 ├── files/                     # Container config (policy.json, registry configs)
 ├── .tekton/                   # Tekton CI/CD pipelines
 │   ├── build-pipeline.yaml
@@ -42,7 +44,8 @@ There is no Makefile. The project is entirely built via `Containerfile` using mu
 2. **opm-builder** — builds `opm` binary
 3. **kustomize-builder** — builds `kustomize` binary
 4. **controller-gen-builder** — builds `controller-gen` binary
-5. **Final stage** — copies all binaries into a UBI 9 Go toolset image
+5. **yq-builder** — builds `yq` binary
+6. **Final stage** — copies all binaries into a UBI 9 Go toolset image
 
 All binaries are built statically: `CGO_ENABLED=0 GOOS=linux`.
 

--- a/Containerfile
+++ b/Containerfile
@@ -22,6 +22,12 @@ COPY --chown=default ./controller-tools/. /opt/app-root/src/
 WORKDIR /opt/app-root/src
 RUN ls -l && CGO_ENABLED=0 GOOS=linux go build -a -o controller-gen ./cmd/controller-gen
 
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.5-1770654497 as yq-builder
+
+COPY --chown=default ./yq/. /opt/app-root/src/
+WORKDIR /opt/app-root/src
+RUN ls -l && CGO_ENABLED=0 GOOS=linux go build -a -o yq .
+
 FROM registry.access.redhat.com/ubi9/go-toolset:1.25.5-1770654497
 
 COPY LICENSE /licenses
@@ -29,6 +35,7 @@ COPY --from=osdk-builder /opt/app-root/src/operator-sdk /bin
 COPY --from=opm-builder /opt/app-root/src/opm /bin
 COPY --from=kustomize-builder /opt/app-root/src/kustomize/kustomize /bin
 COPY --from=controller-gen-builder /opt/app-root/src/controller-gen /bin
+COPY --from=yq-builder /opt/app-root/src/yq /bin
 COPY files/policy.json /etc/containers/policy.json
 COPY files/registry.access.redhat.com.yaml /etc/containers/registries.d/registry.access.redhat.com.yaml
 COPY files/registry.redhat.io.yaml /etc/containers/registries.d/registry.redhat.io.yaml

--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@ The builder image contains the following tools:
 - [controller-gen](https://github.com/kubernetes-sigs/controller-tools)
 - [opm](https://github.com/operator-framework/operator-registry)
 - [kustomize](https://kustomize.io/)
+- [yq](https://github.com/mikefarah/yq)
 - [envsubst](https://www.gnu.org/software/gettext/manual/html_node/envsubst-Invocation.html)
 
 Refer to the [.gitmodules](.gitmodules) file in order
-to see the versions of `operator-sdk`, `controller-tools`, `operator-registry`, and `kustomize`.
+to see the versions of `operator-sdk`, `controller-tools`, `operator-registry`, `kustomize`, and `yq`.
 
 ## Usage
 


### PR DESCRIPTION
Add yq (mikefarah/yq) as a git submodule and build it as a static binary in a new multi-stage build step, following the same pattern as the other tools in the image.

## Summary by Sourcery

Add the yq CLI to the operator-sdk-builder container image as a statically built binary sourced from a new git submodule and multi-stage build step.

New Features:
- Include the yq YAML/JSON/XML processor in the final operator-sdk-builder image.

Enhancements:
- Extend the multi-stage Containerfile build pipeline with a dedicated yq-builder stage that produces a static yq binary.
- Document yq as part of the included tooling and repository submodules in AGENTS.md.

Documentation:
- Update AGENTS.md to list yq among the bundled tools and describe its submodule location.